### PR TITLE
Builder api extension

### DIFF
--- a/src-test/unit_tests.cpp
+++ b/src-test/unit_tests.cpp
@@ -2074,7 +2074,7 @@ TEST(ErrorHandlingTests, DoubleSmallPrintBuffer) {
 }
 
 TEST(ErrorHandlingTests, MultipleDoublesSmallPrintBuffer) {
-    char json[] = "[0.123456,6.0]";
+    char json[] = "[0.123456,6.9]";
     char out[ARRAY_COUNT(json) + 1];
     memset(out, '\n', ARRAY_COUNT(out));
 
@@ -2120,7 +2120,7 @@ TEST(ErrorHandlingTests, PrintStringPartially) {
 }
 
 TEST(ErrorHandlingTests, PrintCompositionOfObjectsAndArraysPartially) {
-    char json[] = R"({"id":5,"values":[{},[],{"key":"val","key2":"val2"},[12,34],5.0]})";
+    char json[] = R"({"id":5,"values":[{},[],{"key":"val","key2":"val2"},[12,34],5.4]})";
     char out[ARRAY_COUNT(json) + 1];
     memset(out, '\n', ARRAY_COUNT(out));
 
@@ -2263,7 +2263,7 @@ TEST(PrintTests, PrintEmtpyObject) {
 }
 
 TEST(PrintTests, PrintNumericArray) {
-    const char json[] = R"([1,2.10101,3,4.123456e+100,5.0,-6])";
+    const char json[] = R"([1,2.10101,3,4.123456e+100,5.1,-6])";
     const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
 
     assert(!QAJ4C_is_error(value));
@@ -2351,7 +2351,7 @@ TEST(PrintTests, PrintMultiLayerObject) {
 }
 
 TEST(PrintTests, PrintDoubleArray) {
-    const char json[] = R"([0.0])";
+    const char json[] = R"([0.1])";
     const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
 
     assert(!QAJ4C_is_error(value));

--- a/src-test/unit_tests.cpp
+++ b/src-test/unit_tests.cpp
@@ -729,19 +729,19 @@ TEST(SimpleParsingTests, ParseObjectCheckOptimizedNoChangeLater) {
 
     for( size_t i = 0; i < size; ++i )
     {
-		assert(buff1[i] == buff2[i]);
+        assert(buff1[i] == buff2[i]);
     }
 
     assert(QAJ4C_is_object(value));
     assert(QAJ4C_object_size(value) == 5);
     assert(QAJ4C_get_internal_type(value) == QAJ4C_OBJECT_SORTED);
 
-	QAJ4C_object_optimize((QAJ4C_Value*) value);
+    QAJ4C_object_optimize((QAJ4C_Value*) value);
 
-	// compare the content with the previously backuped content.
+    // compare the content with the previously backuped content.
     for( size_t i = 0; i < size; ++i )
     {
-		assert(buff1[i] == buff2[i]);
+        assert(buff1[i] == buff2[i]);
     }
 
 }
@@ -764,7 +764,7 @@ TEST(SimpleParsingTests, ParseObjectCheckNonOptimizedAndOptimizeLater) {
     assert(QAJ4C_object_size(value) == 5);
     assert(QAJ4C_get_internal_type(value) == QAJ4C_OBJECT);
 
-	QAJ4C_object_optimize((QAJ4C_Value*) value);
+    QAJ4C_object_optimize((QAJ4C_Value*) value);
     assert(QAJ4C_get_internal_type(value) == QAJ4C_OBJECT_SORTED);
 
     free((void*)value);
@@ -1052,7 +1052,7 @@ TEST(ErrorHandlingTests, InvalidUnicodeSequence) {
  * will invoke the fatal error handler function and not cause segmentation faults or whatever.
  */
 TEST(ErrorHandlingTests, BuilderOverflowArray) {
-	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
+    QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
 
     static bool called = false;
     auto lambda = [](){
@@ -1073,7 +1073,7 @@ TEST(ErrorHandlingTests, BuilderOverflowArray) {
  * will invoke the fatal error handler function and not cause segmentation faults or whatever.
  */
 TEST(ErrorHandlingTests, BuilderOverflowObject) {
-	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
+    QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
 
     static bool called = false;
     auto lambda = [](){
@@ -1093,7 +1093,7 @@ TEST(ErrorHandlingTests, BuilderOverflowObject) {
  * will invoke the fatal error handler function and not cause segmentation faults or whatever.
  */
 TEST(ErrorHandlingTests, BuilderOverflowString) {
-	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
+    QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
 
     static bool called = false;
     auto lambda = [](){
@@ -1114,7 +1114,7 @@ TEST(ErrorHandlingTests, BuilderOverflowString) {
  * with the object memory space.
  */
 TEST(ErrorHandlingTests, BuilderOverflowString2) {
-	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 256);
+    QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 256);
     builder.cur_obj_pos = builder.cur_str_pos;
 
     static bool called = false;
@@ -1459,7 +1459,7 @@ TEST(ErrorHandlingTests, ParseMultipleLongStrings) {
  * the default value will be returned in case a custom fatal function is set.
  */
 TEST(DomObjectAccessTests, ObjectAccess) {
-	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
+    QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
     QAJ4C_Value value;
     QAJ4C_set_object(&value, 0, &builder);
 
@@ -1529,7 +1529,7 @@ TEST(DomObjectAccessTests, IncorrectObjectAccess) {
  * the default value will be returned in case a custom fatal function is set.
  */
 TEST(DomObjectAccessTests, ArrayAccess) {
-	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
+    QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
     QAJ4C_Value value;
     QAJ4C_set_array(&value, 0, &builder);
 
@@ -2002,7 +2002,7 @@ TEST(DomObjectAccessTests, StringCopy) {
     const char* str = "abcdefghijklmnopqrstuvwxy";
     uint8_t buff[strlen(str) * 2];
 
-	QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     QAJ4C_set_string_copy(&value, str, &builder);
     assert(QAJ4C_string_equals(&value, str));
@@ -2211,10 +2211,10 @@ TEST(PrintTests, PrintErrorObject) {
  */
 TEST(PrintTests, PrintDoubleCornercase) {
     QAJ4C_Value value;
-	double d = -63.999999999999943;
+    double d = -63.999999999999943;
     char buffer[64] = {'\0'};
 
-	QAJ4C_set_double(&value, d);
+    QAJ4C_set_double(&value, d);
     size_t out = QAJ4C_sprint(&value, buffer, ARRAY_COUNT(buffer));
     assert( '\0' == buffer[out - 1]);
     assert( '.' != buffer[out - 2]);
@@ -2226,12 +2226,32 @@ TEST(PrintTests, PrintDoubleCornercase) {
  */
 TEST(PrintTests, PrintDoubleCornercase2) {
     QAJ4C_Value value;
-	double d = -1.0e-10;
+    double d = -1.0e-10;
     char buffer[64] = {'\0'};
 
-	QAJ4C_set_double(&value, d);
+    QAJ4C_set_double(&value, d);
     size_t out = QAJ4C_sprint(&value, buffer, ARRAY_COUNT(buffer));
     assert( strchr( buffer, 'e') != nullptr );
+}
+
+TEST(PrintTests, PrintSecondCharIsE) {
+   QAJ4C_Value value;
+   double d = 2.0e-308;
+   char buffer[64] = {'\0'};
+
+   QAJ4C_set_double(&value, d);
+   size_t out = QAJ4C_sprint(&value, buffer, ARRAY_COUNT(buffer));
+   assert( strchr( buffer, 'e') != nullptr );
+}
+
+TEST(PrintTests, PrintDoubleZero) {
+   QAJ4C_Value value;
+   double d = 0;
+   char buffer[64] = {'\0'};
+
+   QAJ4C_set_double(&value, d);
+   size_t out = QAJ4C_sprint(&value, buffer, ARRAY_COUNT(buffer));
+   assert( strcmp("0", buffer) == 0 );
 }
 
 TEST(PrintTests, PrintCorruptValue) {
@@ -2287,7 +2307,7 @@ TEST(A, PrintAllTwoDigitDecimalsArray) {
     *p = '[';
     p += 1;
     for (unsigned i = 0; i< 100; ++i) {
-    	p += sprintf(p, "%u,", i);
+        p += sprintf(p, "%u,", i);
     }
     *(p-1) = ']';
     const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
@@ -2662,7 +2682,7 @@ TEST(VariousTests, ComparisonAndCopyTest) {
     uint8_t buffer2[buff_size];
     const QAJ4C_Value* value_1;
 
-	QAJ4C_Builder builder = QAJ4C_builder_create(buffer2, buff_size);
+    QAJ4C_Builder builder = QAJ4C_builder_create(buffer2, buff_size);
     QAJ4C_builder_init(&builder, buffer2, buff_size);
 
     QAJ4C_parse(json, buffer, buff_size, &value_1);
@@ -2678,8 +2698,8 @@ TEST(VariousTests, ComparisonAndCopyTest) {
 TEST(VariousTests, CopyNotFullyFilledObject) {
     uint8_t buff1[256];
     uint8_t buff2[ARRAY_COUNT(buff1)];
-	QAJ4C_Builder builder1 = QAJ4C_builder_create(buff1, ARRAY_COUNT(buff1));
-	QAJ4C_Builder builder2 = QAJ4C_builder_create(buff2, ARRAY_COUNT(buff2));
+    QAJ4C_Builder builder1 = QAJ4C_builder_create(buff1, ARRAY_COUNT(buff1));
+    QAJ4C_Builder builder2 = QAJ4C_builder_create(buff2, ARRAY_COUNT(buff2));
 
     QAJ4C_Value* root = QAJ4C_builder_get_document(&builder1);
     QAJ4C_set_object(root, 3, &builder1);
@@ -2756,24 +2776,24 @@ TEST(VariousTests, CheckSizes) {
 }
 
 TEST(VariousTests, ResetBuilder) {
-	char buff[256];
+    char buff[256];
 
-	QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
-	QAJ4C_Builder builder2 = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder2 = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
-	assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) == 0);
+    assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) == 0);
 
-	// alter the builder
-	QAJ4C_set_array(QAJ4C_builder_get_document(&builder), 10, &builder);
+    // alter the builder
+    QAJ4C_set_array(QAJ4C_builder_get_document(&builder), 10, &builder);
 
-	// compare should not result in the builders are equal
-	assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) != 0);
+    // compare should not result in the builders are equal
+    assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) != 0);
 
-	// now reset the builder
-	QAJ4C_builder_reset(&builder);
+    // now reset the builder
+    QAJ4C_builder_reset(&builder);
 
-	// builders should be equal again
-	assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) == 0);
+    // builders should be equal again
+    assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) == 0);
 }
 
 

--- a/src-test/unit_tests.cpp
+++ b/src-test/unit_tests.cpp
@@ -1052,8 +1052,7 @@ TEST(ErrorHandlingTests, InvalidUnicodeSequence) {
  * will invoke the fatal error handler function and not cause segmentation faults or whatever.
  */
 TEST(ErrorHandlingTests, BuilderOverflowArray) {
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, NULL, 0);
+	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
 
     static bool called = false;
     auto lambda = [](){
@@ -1074,8 +1073,7 @@ TEST(ErrorHandlingTests, BuilderOverflowArray) {
  * will invoke the fatal error handler function and not cause segmentation faults or whatever.
  */
 TEST(ErrorHandlingTests, BuilderOverflowObject) {
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, NULL, 0);
+	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
 
     static bool called = false;
     auto lambda = [](){
@@ -1095,8 +1093,7 @@ TEST(ErrorHandlingTests, BuilderOverflowObject) {
  * will invoke the fatal error handler function and not cause segmentation faults or whatever.
  */
 TEST(ErrorHandlingTests, BuilderOverflowString) {
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, NULL, 0);
+	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
 
     static bool called = false;
     auto lambda = [](){
@@ -1117,8 +1114,7 @@ TEST(ErrorHandlingTests, BuilderOverflowString) {
  * with the object memory space.
  */
 TEST(ErrorHandlingTests, BuilderOverflowString2) {
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, NULL, 256);
+	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 256);
     builder.cur_obj_pos = builder.cur_str_pos;
 
     static bool called = false;
@@ -1397,8 +1393,7 @@ TEST(ErrorHandlingTests, BufferTooSmallToStoreStatsticsReallocFailsWithObject) {
  */
 TEST(ErrorHandlingTests, LookupMemberUninitializedObject) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
     QAJ4C_set_object(value_ptr, 4, &builder);
@@ -1464,7 +1459,7 @@ TEST(ErrorHandlingTests, ParseMultipleLongStrings) {
  * the default value will be returned in case a custom fatal function is set.
  */
 TEST(DomObjectAccessTests, ObjectAccess) {
-    QAJ4C_Builder builder;
+	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
     QAJ4C_Value value;
     QAJ4C_set_object(&value, 0, &builder);
 
@@ -1534,7 +1529,7 @@ TEST(DomObjectAccessTests, IncorrectObjectAccess) {
  * the default value will be returned in case a custom fatal function is set.
  */
 TEST(DomObjectAccessTests, ArrayAccess) {
-    QAJ4C_Builder builder;
+	QAJ4C_Builder builder = QAJ4C_builder_create(NULL, 0);
     QAJ4C_Value value;
     QAJ4C_set_array(&value, 0, &builder);
 
@@ -2007,8 +2002,7 @@ TEST(DomObjectAccessTests, StringCopy) {
     const char* str = "abcdefghijklmnopqrstuvwxy";
     uint8_t buff[strlen(str) * 2];
 
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+	QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     QAJ4C_set_string_copy(&value, str, &builder);
     assert(QAJ4C_string_equals(&value, str));
@@ -2270,6 +2264,50 @@ TEST(PrintTests, PrintEmtpyObject) {
 
 TEST(PrintTests, PrintNumericArray) {
     const char json[] = R"([1,2.10101,3,4.123456e+100,5.0,-6])";
+    const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
+
+    assert(!QAJ4C_is_error(value));
+
+    char output[ARRAY_COUNT(json)];
+    size_t out = QAJ4C_sprint(value, output, ARRAY_COUNT(output));
+    assert(ARRAY_COUNT(output) == out);
+
+    assert(strcmp(json, output) == 0);
+
+    free((void*)value);
+}
+
+/**
+ * Parses and prints a row of decimals of base 10 (regression test)
+ */
+TEST(A, PrintAllTwoDigitDecimalsArray) {
+    char json[512];
+
+    char* p = json;
+    *p = '[';
+    p += 1;
+    for (unsigned i = 0; i< 100; ++i) {
+    	p += sprintf(p, "%u,", i);
+    }
+    *(p-1) = ']';
+    const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
+
+    assert(!QAJ4C_is_error(value));
+
+    char output[strlen(json)+1];
+    size_t out = QAJ4C_sprint(value, output, ARRAY_COUNT(output));
+    assert(ARRAY_COUNT(output) == out);
+
+    assert(strcmp(json, output) == 0);
+
+    free((void*)value);
+}
+
+/**
+ * Parses and prints a row of decimals of base 10 (regression test)
+ */
+TEST(PrintTests, PrintDecimalsArray) {
+    const char json[] = R"([1,10,100,1000,10000,100000])";
     const QAJ4C_Value* value = QAJ4C_parse_opt_dynamic(json, ARRAY_COUNT(json), 0, realloc);
 
     assert(!QAJ4C_is_error(value));
@@ -2624,7 +2662,7 @@ TEST(VariousTests, ComparisonAndCopyTest) {
     uint8_t buffer2[buff_size];
     const QAJ4C_Value* value_1;
 
-    QAJ4C_Builder builder;
+	QAJ4C_Builder builder = QAJ4C_builder_create(buffer2, buff_size);
     QAJ4C_builder_init(&builder, buffer2, buff_size);
 
     QAJ4C_parse(json, buffer, buff_size, &value_1);
@@ -2640,10 +2678,8 @@ TEST(VariousTests, ComparisonAndCopyTest) {
 TEST(VariousTests, CopyNotFullyFilledObject) {
     uint8_t buff1[256];
     uint8_t buff2[ARRAY_COUNT(buff1)];
-    QAJ4C_Builder builder1;
-    QAJ4C_builder_init(&builder1, buff1, ARRAY_COUNT(buff1));
-    QAJ4C_Builder builder2;
-    QAJ4C_builder_init(&builder2, buff2, ARRAY_COUNT(buff2));
+	QAJ4C_Builder builder1 = QAJ4C_builder_create(buff1, ARRAY_COUNT(buff1));
+	QAJ4C_Builder builder2 = QAJ4C_builder_create(buff2, ARRAY_COUNT(buff2));
 
     QAJ4C_Value* root = QAJ4C_builder_get_document(&builder1);
     QAJ4C_set_object(root, 3, &builder1);
@@ -2683,9 +2719,7 @@ TEST(VariousTests, ErrorsCannotBeCopied) {
     size_t buff_size = QAJ4C_calculate_max_buffer_size(json);
     uint8_t buffer1[buff_size];
     uint8_t buffer2[buff_size];
-    QAJ4C_Builder builder;
-
-    QAJ4C_builder_init(&builder, buffer2, buff_size);
+    QAJ4C_Builder builder = QAJ4C_builder_create(buffer2, buff_size);
 
     static int count = 0;
     auto lambda = []{ count++; }; // set the error method (else the compare will send a signal)
@@ -2720,6 +2754,28 @@ TEST(VariousTests, CheckSizes) {
 
     assert(sizeof(QAJ4C_Member) == 2 * sizeof(QAJ4C_Value));
 }
+
+TEST(VariousTests, ResetBuilder) {
+	char buff[256];
+
+	QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
+	QAJ4C_Builder builder2 = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
+
+	assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) == 0);
+
+	// alter the builder
+	QAJ4C_set_array(QAJ4C_builder_get_document(&builder), 10, &builder);
+
+	// compare should not result in the builders are equal
+	assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) != 0);
+
+	// now reset the builder
+	QAJ4C_builder_reset(&builder);
+
+	// builders should be equal again
+	assert(QAJ4C_MEMCMP(&builder, &builder2, sizeof(builder)) == 0);
+}
+
 
 TEST(StrictParsingTests, ParseValidNumericValues) {
     const char json[] = R"([0, 1.0, 0.015, -0.5, -0.005, -256])";
@@ -2791,8 +2847,7 @@ TEST(StrictParsingTests, ParseArrayTrailingComma) {
 
 TEST(DomCreation, CreateArray) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     auto lambda = []{};
 
@@ -2830,8 +2885,7 @@ TEST(DomCreation, CreateObject) {
     static const char* key5 = "xyz";
 
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     auto lambda = []{};
 
@@ -2886,8 +2940,7 @@ TEST(DomCreation, CreateObject) {
 
 TEST(DomCreation, OptimizeEmptyObject) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
     QAJ4C_set_object(value_ptr, 0, &builder);
@@ -2897,8 +2950,7 @@ TEST(DomCreation, OptimizeEmptyObject) {
 
 TEST(DomCreation, OptimizeUninitializedObject) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
     QAJ4C_set_object(value_ptr, 4, &builder);
@@ -2908,8 +2960,7 @@ TEST(DomCreation, OptimizeUninitializedObject) {
 
 TEST(DomCreation, OptimizeLowFilledObject) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
     QAJ4C_set_object(value_ptr, 4, &builder);
@@ -2926,8 +2977,7 @@ TEST(DomCreation, OptimizeLowFilledObject) {
  */
 TEST(DomCreation, PrintIncompleteObject) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
 
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
     QAJ4C_set_object(value_ptr, 4, &builder);
@@ -2943,8 +2993,7 @@ TEST(DomCreation, PrintIncompleteObject) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegers) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 2, false, &builder);
@@ -2963,8 +3012,7 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegers) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersAndUnusedFields) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, false, &builder);
@@ -2984,8 +3032,7 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegersAndUnusedFields) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersDeduplication) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, true, &builder);
@@ -3006,8 +3053,7 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegersDeduplication) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersNoDeduplication) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, false, &builder);
@@ -3027,8 +3073,7 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegersNoDeduplication) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersKeysAsCopy) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 2, false, &builder);
@@ -3046,8 +3091,7 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegersKeysAsCopy) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersAndUnusedFieldsKeysAsCopy) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, false, &builder);
@@ -3067,8 +3111,7 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegersAndUnusedFieldsKeysAsCopy) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersDeduplicationKeysAsCopy) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, true, &builder);
@@ -3088,8 +3131,7 @@ TEST(ObjectBuilderTests, SimpleObjectWithIntegersDeduplicationKeysAsCopy) {
  */
 TEST(ObjectBuilderTests, SimpleObjectWithIntegersNoDeduplicationKeysAsCopy) {
     uint8_t buff[256];
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* value_ptr = QAJ4C_builder_get_document(&builder);
 
     QAJ4C_Object_builder obj_builder = QAJ4C_object_builder_init(value_ptr, 4, false, &builder);
@@ -3151,8 +3193,7 @@ TEST(CornerCaseTests, PrintArrayWithNullValues) {
         buff[i] = 0xFF;
     }
 
-    QAJ4C_Builder builder;
-    QAJ4C_builder_init(&builder, buff, ARRAY_COUNT(buff));
+    QAJ4C_Builder builder = QAJ4C_builder_create(buff, ARRAY_COUNT(buff));
     QAJ4C_Value* root_node = QAJ4C_builder_get_document(&builder);
     QAJ4C_set_object(root_node, 5, &builder);
 

--- a/src/qajson4c/qajson4c.c
+++ b/src/qajson4c/qajson4c.c
@@ -320,6 +320,13 @@ const QAJ4C_Value* QAJ4C_array_get( const QAJ4C_Value* value_ptr, size_t index )
     return ((QAJ4C_Array*) value_ptr)->top + index;
 }
 
+QAJ4C_Builder QAJ4C_builder_create( void* buff, size_t buff_size )
+{
+   QAJ4C_Builder result;
+   QAJ4C_builder_init( &result, buff, buff_size );
+   return result;
+}
+
 void QAJ4C_builder_init( QAJ4C_Builder* me, void* buff, size_t buff_size ) {
     me->buffer = buff;
     me->buffer_size = buff_size;
@@ -328,6 +335,11 @@ void QAJ4C_builder_init( QAJ4C_Builder* me, void* buff, size_t buff_size ) {
     me->cur_obj_pos = sizeof(QAJ4C_Value);
     /* strings from end to front */
     me->cur_str_pos = buff_size;
+}
+
+void QAJ4C_builder_reset( QAJ4C_Builder* me )
+{
+   QAJ4C_builder_init( me, me->buffer, me->buffer_size );
 }
 
 QAJ4C_Value* QAJ4C_builder_get_document( QAJ4C_Builder* builder ) {

--- a/src/qajson4c/qajson4c.h
+++ b/src/qajson4c/qajson4c.h
@@ -523,9 +523,19 @@ size_t QAJ4C_array_size( const QAJ4C_Value* value_ptr );
 const QAJ4C_Value* QAJ4C_array_get( const QAJ4C_Value* value_ptr, size_t index );
 
 /**
+ * Creates the builder with the given buffer.
+ */
+QAJ4C_Builder QAJ4C_builder_create( void* buff, size_t buff_size );
+
+/**
  * Initializes the builder with the given buffer.
  */
 void QAJ4C_builder_init( QAJ4C_Builder* me, void* buff, size_t buff_size );
+
+/**
+ * Creates the builder with the given buffer.
+ */
+void QAJ4C_builder_reset( QAJ4C_Builder* me );
 
 /**
  * This method will retrieve the document from the builder.

--- a/src/qajson4c/qajson4c_internal.c
+++ b/src/qajson4c/qajson4c_internal.c
@@ -1239,15 +1239,7 @@ bool QAJ4C_print_callback_double( double d, QAJ4C_print_buffer_callback_fn callb
     if ((d * 0) != 0) {
         result = QAJ4C_print_callback_constant(QAJ4C_NULL_STR, QAJ4C_NULL_STR_LEN, callback, ptr);
     } else {
-        double absd = d < 0 ? -d: d;
-        double delta = (int64_t)(d) - d;
-        double absDelta = delta < 0 ? -delta : delta;
-        int printf_result = 0;
-        if ((absDelta <= DBL_EPSILON) && (absd < 1.0e60)) {
-            printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%.1f", d);
-        } else {
-            printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%.10g", d);
-        }
+        int printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%1.10g", d);
 
         if (printf_result > 0 && printf_result < BUFFER_SIZE) {
             result = callback(ptr, buffer, printf_result);

--- a/src/qajson4c/qajson4c_internal.c
+++ b/src/qajson4c/qajson4c_internal.c
@@ -1236,14 +1236,15 @@ bool QAJ4C_print_callback_double( double d, QAJ4C_print_buffer_callback_fn callb
     char buffer[BUFFER_SIZE];
     bool result = true;
 
-    if ((d * 0) != 0) {
-        result = QAJ4C_print_callback_constant(QAJ4C_NULL_STR, QAJ4C_NULL_STR_LEN, callback, ptr);
-    } else {
-        int printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%1.10g", d);
+    int printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%1.10g", d);
 
-        if (printf_result > 0 && printf_result < BUFFER_SIZE) {
-            result = callback(ptr, buffer, printf_result);
-        }
+    if ( printf_result > 0 && printf_result < BUFFER_SIZE && (QAJ4C_is_digit(buffer[1]) || QAJ4C_is_double_separation_char(buffer[1]) || printf_result == 1) )
+    {
+       result = callback(ptr, buffer, printf_result);
+    }
+    else
+    {
+       result = QAJ4C_print_callback_constant(QAJ4C_NULL_STR, QAJ4C_NULL_STR_LEN, callback, ptr);
     }
     return result;
 }

--- a/src/qajson4c/qajson4c_internal.c
+++ b/src/qajson4c/qajson4c_internal.c
@@ -1305,13 +1305,13 @@ bool QAJ4C_print_callback_string( const char *string, QAJ4C_print_buffer_callbac
     bool result = callback(ptr, "\"", 1);
 
     while( result && p[size] != '\0' ) {
-        char c = p[size];
+    	uint8_t c = (uint8_t)p[size];
         if (QAJ4C_UNLIKELY(c < 32 || c == '"' || c == '/' || c == '\\')) {
             if ( c >= 32 ) {
                 /* set the char in the 2x range so we can use the replacement buffer to replace the string. */
                 c = (c & 0xF) | 0x20;
             }
-            const char* replacement_string = replacement_buf[(uint8_t)c];
+            const char* replacement_string = replacement_buf[c];
             result = result && callback(ptr, p, size); /* flush the string until now */
             result = result && callback(ptr, replacement_string, strlen(replacement_string));
             p = p + size + 1;

--- a/src/qajson4c/qajson4c_internal.c
+++ b/src/qajson4c/qajson4c_internal.c
@@ -315,6 +315,7 @@ static void QAJ4C_first_pass_object( QAJ4C_First_pass_parser* parser, int depth 
 
     if (parser->max_depth < depth) {
         QAJ4C_first_pass_parser_set_error(parser, QAJ4C_ERROR_DEPTH_OVERFLOW);
+        return;
     }
 
     QAJ4C_first_pass_skip_whitespaces_and_comments(parser);
@@ -356,7 +357,7 @@ static void QAJ4C_first_pass_object( QAJ4C_First_pass_parser* parser, int depth 
         QAJ4C_first_pass_parser_set_error(parser, QAJ4C_ERROR_JSON_MESSAGE_TRUNCATED);
     }
 
-    if (parser->builder != NULL) {
+    if (parser->builder != NULL && parser->err_code == QAJ4C_ERROR_NO_ERROR) {
         size_type* obj_data = QAJ4C_first_pass_fetch_stats_buffer(parser, storage_pos);
         if (obj_data != NULL) {
             *obj_data = member_count;
@@ -372,6 +373,7 @@ static void QAJ4C_first_pass_array( QAJ4C_First_pass_parser* parser, int depth )
 
     if (parser->max_depth < depth) {
         QAJ4C_first_pass_parser_set_error(parser, QAJ4C_ERROR_DEPTH_OVERFLOW);
+        return;
     }
 
     QAJ4C_first_pass_skip_whitespaces_and_comments(parser);
@@ -401,7 +403,7 @@ static void QAJ4C_first_pass_array( QAJ4C_First_pass_parser* parser, int depth )
 
     QAJ4C_json_message_forward(parser->msg);
 
-    if (parser->builder != NULL) {
+    if (parser->builder != NULL && parser->err_code == QAJ4C_ERROR_NO_ERROR) {
         size_type* obj_data = QAJ4C_first_pass_fetch_stats_buffer( parser, storage_pos );
         if ( obj_data != NULL ) {
             *obj_data = member_count;
@@ -988,9 +990,9 @@ static QAJ4C_Value* QAJ4C_create_error_description( QAJ4C_First_pass_parser* par
 static size_type* QAJ4C_first_pass_fetch_stats_buffer( QAJ4C_First_pass_parser* parser, size_type storage_pos ) {
     QAJ4C_Builder* builder = parser->builder;
     size_t in_buffer_pos = storage_pos * sizeof(size_type);
-    if (in_buffer_pos >= builder->buffer_size) {
+    if (in_buffer_pos + sizeof(size_type) > builder->buffer_size) {
         void *tmp;
-        size_t required_size = parser->amount_nodes * sizeof(QAJ4C_Value);
+        size_t required_size = QAJ4C_calculate_max_buffer_parser(parser);
         if (parser->realloc_callback == NULL) {
             QAJ4C_first_pass_parser_set_error(parser,
                                               QAJ4C_ERROR_STORAGE_BUFFER_TO_SMALL);
@@ -1103,20 +1105,12 @@ int QAJ4C_strcmp( const QAJ4C_Value* lhs, const QAJ4C_Value* rhs ) {
     size_type rhs_size = QAJ4C_get_string_length(rhs);
     const char* lhs_string = QAJ4C_get_string(lhs);
     const char* rhs_string = QAJ4C_get_string(rhs);
-    size_type i;
 
     if (lhs_size != rhs_size) {
         return lhs_size - rhs_size;
     }
-
-    for ( i = 0; i < lhs_size; ++i) {
-        if (lhs_string[i] != rhs_string[i]) {
-            return lhs_string[i] - rhs_string[i];
-        }
-    }
-    return 0;
+    return QAJ4C_MEMCMP(lhs_string, rhs_string, lhs_size);
 }
-
 
 /*
  * In some situations objects are not fully filled ... all unset members (key is null)
@@ -1249,29 +1243,13 @@ bool QAJ4C_print_callback_double( double d, QAJ4C_print_buffer_callback_fn callb
         double delta = (int64_t)(d) - d;
         double absDelta = delta < 0 ? -delta : delta;
         int printf_result = 0;
-        bool strip_trailing_zeros = true;
         if ((absDelta <= DBL_EPSILON) && (absd < 1.0e60)) {
             printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%.1f", d);
-        } else if ((absd < 1.0e-6) || (absd > 1.0e9)) {
-            printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%e", d);
-            strip_trailing_zeros = false;
         } else {
-            printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%f", d);
+            printf_result = QAJ4C_SNPRINTF(buffer, BUFFER_SIZE, "%.10g", d);
         }
 
         if (printf_result > 0 && printf_result < BUFFER_SIZE) {
-            if (strip_trailing_zeros) {
-                int pos = printf_result;
-                while (pos > 0 && buffer[pos - 1] == '0') {
-                    pos -= 1;
-                }
-                if (buffer[pos - 1] == '.') {
-                    pos += 1;
-                }
-                buffer[pos] = '\0';
-                printf_result = pos;
-            }
-
             result = callback(ptr, buffer, printf_result);
         }
     }
@@ -1308,15 +1286,12 @@ bool QAJ4C_print_callback_int64( int64_t value, QAJ4C_print_buffer_callback_fn c
 {
     static int BUFFER_SIZE = 32;
     char buffer[BUFFER_SIZE];
-    bool negative = value < 0;
-    char* pos_ptr = QAJ4C_do_print_uint64(value * -1, buffer, BUFFER_SIZE);
 
-    /* prepend the sign char, in case the number is negative */
-    if ( negative )
-    {
-        pos_ptr -= 1;
-        *pos_ptr = '-';
-    }
+	/* this callback is only called with a negative number as it otherwise has been classified uint64 */
+    char* pos_ptr = QAJ4C_do_print_uint64(-value, buffer + 1, BUFFER_SIZE - 1);
+
+	pos_ptr -= 1;
+	*pos_ptr = '-';
     return callback(ptr, pos_ptr, (buffer + BUFFER_SIZE) - pos_ptr);
 }
 

--- a/src/qajson4c/qajson_stdwrap.h
+++ b/src/qajson4c/qajson_stdwrap.h
@@ -70,7 +70,7 @@
 #endif
 
 #define QAJ4C_STRLEN strlen
-#define QAJ4C_STRNCMP strncmp
+#define QAJ4C_MEMCMP memcmp
 #define QAJ4C_MEMMOVE memmove
 #define QAJ4C_MEMCPY memcpy
 


### PR DESCRIPTION
- Added methods for simpler use of the QAJ4C_Builder.
- Reworked double printing and removed code
  - now trailing zeros are by printf automatically
  - doubles "0.0" will be printed as "0" and thus be different!
- Resolved segmentation fault for non ascii chars (thus negative)